### PR TITLE
Localize statistic labels in responsive redesign

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,25 +7,223 @@
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#f6f6f6">
   <style>
-    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:24px;line-height:1.6}
-    h1{font-size:1.3rem;margin:0 0 12px}
-    textarea{width:100%;min-height:40vh;padding:12px;font-size:1rem}
-    .stats{display:flex;gap:16px;margin:8px 0}
-    .box{padding:8px 12px;border:1px solid #ddd;border-radius:8px;background:#fff}
-    button{padding:8px 12px;border:1px solid #ddd;border-radius:6px;background:#fafafa}
-    footer{margin-top:16px;color:#666;font-size:.9rem}
+    :root {
+      color-scheme: light;
+      --accent: #4f46e5;
+      --accent-soft: #a855f7;
+      --surface: rgba(255, 255, 255, 0.82);
+      --surface-strong: rgba(255, 255, 255, 0.92);
+      --shadow: 0 22px 45px -20px rgba(79, 70, 229, 0.55);
+      --radius-lg: 24px;
+    }
+
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: clamp(16px, 5vw, 48px);
+      font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", system-ui, -apple-system, "Segoe UI", sans-serif;
+      line-height: 1.75;
+      background: radial-gradient(circle at top, #f5f3ff, #ede9fe 45%, #fff);
+      color: #1f2933;
+      overflow-x: hidden;
+    }
+
+    main {
+      position: relative;
+      width: min(880px, 100%);
+      padding: clamp(24px, 6vw, 56px);
+      border-radius: var(--radius-lg);
+      background: linear-gradient(145deg, var(--surface), var(--surface-strong));
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(16px);
+      border: 1px solid rgba(255, 255, 255, 0.55);
+      overflow: hidden;
+    }
+
+    main::before {
+      content: "";
+      position: absolute;
+      inset: -40% -10% auto auto;
+      width: clamp(180px, 45vw, 320px);
+      aspect-ratio: 1;
+      background: radial-gradient(circle, rgba(79, 70, 229, 0.18), transparent 60%);
+      z-index: 0;
+      transform: rotate(12deg);
+    }
+
+    h1 {
+      font-size: clamp(1.45rem, 5vw, 2.1rem);
+      letter-spacing: 0.04em;
+      margin: 0 0 12px;
+      color: #312e81;
+      position: relative;
+      z-index: 1;
+    }
+
+    .lead {
+      margin: 0 0 clamp(18px, 4vw, 28px);
+      color: #4a5568;
+      font-size: clamp(0.95rem, 3.5vw, 1.05rem);
+      position: relative;
+      z-index: 1;
+    }
+
+    textarea {
+      width: 100%;
+      min-height: clamp(220px, 45vh, 520px);
+      padding: clamp(14px, 3.6vw, 20px);
+      font-size: clamp(1rem, 3.3vw, 1.1rem);
+      border-radius: 18px;
+      border: 1px solid rgba(79, 70, 229, 0.15);
+      background: rgba(255, 255, 255, 0.95);
+      box-shadow: inset 0 1px 1px rgba(15, 23, 42, 0.05);
+      resize: vertical;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      position: relative;
+      z-index: 1;
+    }
+
+    textarea:focus {
+      outline: none;
+      border-color: rgba(79, 70, 229, 0.45);
+      box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.2);
+    }
+
+    .stats {
+      display: grid;
+      gap: clamp(14px, 4vw, 24px);
+      margin: clamp(20px, 5vw, 32px) 0;
+      grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr));
+      position: relative;
+      z-index: 1;
+    }
+
+    .box {
+      padding: clamp(16px, 4vw, 20px);
+      border-radius: 20px;
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(236, 233, 254, 0.95));
+      border: 1px solid rgba(99, 102, 241, 0.18);
+      box-shadow: 0 10px 25px -18px rgba(79, 70, 229, 0.6);
+      display: grid;
+      gap: 6px;
+      align-content: center;
+      text-align: center;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .box::after {
+      content: "";
+      position: absolute;
+      inset: auto -10% -45% auto;
+      width: clamp(110px, 30vw, 160px);
+      height: clamp(70px, 18vw, 110px);
+      background: radial-gradient(circle, rgba(79, 70, 229, 0.22), transparent 70%);
+      z-index: 0;
+    }
+
+    .box span {
+      font-size: 0.9rem;
+      letter-spacing: 0.06em;
+      color: #4c51bf;
+      font-weight: 600;
+      position: relative;
+      z-index: 1;
+    }
+
+    .box strong {
+      font-size: clamp(1.4rem, 4vw, 1.8rem);
+      color: #312e81;
+      font-weight: 700;
+      position: relative;
+      z-index: 1;
+    }
+
+    button {
+      border: none;
+      border-radius: 999px;
+      padding: clamp(14px, 4vw, 18px) clamp(22px, 8vw, 36px);
+      font-size: clamp(1rem, 3.5vw, 1.05rem);
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      color: #fff;
+      background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+      box-shadow: 0 16px 30px -20px rgba(79, 70, 229, 0.8);
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      position: relative;
+      z-index: 1;
+    }
+
+    button::before {
+      content: "\2715";
+      font-size: 1.05em;
+    }
+
+    button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 20px 36px -18px rgba(79, 70, 229, 0.85);
+    }
+
+    button:active {
+      transform: translateY(0);
+      box-shadow: 0 12px 22px -16px rgba(79, 70, 229, 0.9);
+    }
+
+    footer {
+      margin-top: clamp(20px, 6vw, 32px);
+      color: #475569;
+      font-size: clamp(0.85rem, 3vw, 0.95rem);
+      text-align: center;
+      position: relative;
+      z-index: 1;
+    }
+
+    @media (min-width: 880px) {
+      main {
+        display: grid;
+        gap: clamp(24px, 4vw, 40px);
+      }
+
+      textarea {
+        min-height: 320px;
+      }
+    }
   </style>
 </head>
 <body>
-  <h1>文字数カウンター（PWA）</h1>
-  <textarea id="t" placeholder="ここに文章を入力／貼り付け"></textarea>
-  <div class="stats">
-    <div class="box">文字数：<strong id="chars">0</strong></div>
-    <div class="box">行数：<strong id="lines">0</strong></div>
-    <div class="box">単語数：<strong id="words">0</strong></div>
-  </div>
-  <button id="clear">クリア</button>
-  <footer>オフラインでも使えます。ホーム画面に追加するとアプリ風に使えます。</footer>
+  <main>
+    <h1>文字数カウンター（PWA）</h1>
+    <p class="lead">文章の長さを瞬時に把握できる、やわらかな雰囲気のカウンターツールです。スマホでもデスクトップでも、最適なサイズでお使いください。</p>
+    <textarea id="t" placeholder="ここに文章を入力／貼り付け"></textarea>
+    <div class="stats">
+      <div class="box">
+        <span>文字数</span>
+        <strong id="chars">0</strong>
+      </div>
+      <div class="box">
+        <span>行数</span>
+        <strong id="lines">0</strong>
+      </div>
+      <div class="box">
+        <span>単語数</span>
+        <strong id="words">0</strong>
+      </div>
+    </div>
+    <button id="clear">クリア</button>
+    <footer>オフラインでも使えます。ホーム画面に追加するとアプリのように素早くアクセスできます。</footer>
+  </main>
 
   <script>
     const $ = s => document.querySelector(s);


### PR DESCRIPTION
## Summary
- switch the statistic labels back to Japanese text to match the rest of the UI and avoid merge confusion
- tune the statistic label styling so it reads well without the previous all-uppercase treatment

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d54f37ec28832faae0881389bae376