### PR TITLE
Improve glassmorphism rendering on Chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,11 @@
       padding: clamp(24px, 4vw, 48px);
       box-shadow: var(--shadow);
       backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
       border: 1px solid var(--border);
+      position: relative;
+      overflow: hidden;
+      isolation: isolate;
     }
     header {
       display: flex;
@@ -118,6 +122,8 @@
       position: relative;
       overflow: hidden;
       box-shadow: 0 20px 40px rgba(38, 45, 74, 0.08);
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
     }
     .box::after {
       content: "";
@@ -130,6 +136,14 @@
     }
     .box:hover::after {
       opacity: 1;
+    }
+    @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+      .wrap {
+        background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.78));
+      }
+      .box {
+        background: linear-gradient(140deg, rgba(255, 255, 255, 0.98), rgba(246, 248, 255, 0.82));
+      }
     }
     .box strong {
       display: block;


### PR DESCRIPTION
## Summary
- add WebKit-prefixed backdrop-filter and isolation tweaks to prevent Chrome rendering issues
- provide gradient fallback styles when backdrop-filter is unavailable to keep the polished look

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d5d683d1d8832fba771971152c1c24