### PR TITLE
Add ambient background animation and mascot image reactions

### DIFF
--- a/assets/reaction-calm.svg
+++ b/assets/reaction-calm.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="calm-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f3fff7"/>
+      <stop offset="50%" stop-color="#c2f0dd"/>
+      <stop offset="100%" stop-color="#8edfc2"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="40" fill="url(#calm-bg)"/>
+  <path d="M50 60c8-6 18-10 30-10s22 4 30 10" fill="none" stroke="#69c3a1" stroke-width="10" stroke-linecap="round"/>
+  <path d="M54 86c6 6 12 6 18 0" fill="none" stroke="#2c6e55" stroke-width="8" stroke-linecap="round"/>
+  <path d="M88 86c6 6 12 6 18 0" fill="none" stroke="#2c6e55" stroke-width="8" stroke-linecap="round"/>
+  <path d="M54 108c10 12 42 12 52 0" fill="none" stroke="#2c6e55" stroke-width="8" stroke-linecap="round"/>
+  <circle cx="42" cy="120" r="10" fill="#d7f7eb" opacity="0.7"/>
+  <circle cx="118" cy="120" r="10" fill="#d7f7eb" opacity="0.5"/>
+</svg>

--- a/assets/reaction-energetic.svg
+++ b/assets/reaction-energetic.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="energetic-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fff8e1"/>
+      <stop offset="50%" stop-color="#ffe19a"/>
+      <stop offset="100%" stop-color="#ffc06a"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="40" fill="url(#energetic-bg)"/>
+  <path d="M40 52l12-18 12 10 10-16 14 14 14-16 12 20" fill="none" stroke="#ff8b1f" stroke-width="8" stroke-linecap="round"/>
+  <circle cx="55" cy="74" r="9" fill="#7a3600"/>
+  <circle cx="105" cy="74" r="9" fill="#7a3600"/>
+  <path d="M60 104c8 10 32 10 40 0" fill="none" stroke="#aa4a00" stroke-width="8" stroke-linecap="round"/>
+  <path d="M52 122c12 10 44 10 56 0" fill="none" stroke="#ffd8a0" stroke-width="12" stroke-linecap="round" opacity="0.7"/>
+</svg>

--- a/assets/reaction-happy.svg
+++ b/assets/reaction-happy.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="happy-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fff5f5"/>
+      <stop offset="55%" stop-color="#ffd5e1"/>
+      <stop offset="100%" stop-color="#ffa4cf"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="40" fill="url(#happy-bg)"/>
+  <circle cx="56" cy="66" r="9" fill="#7b184a"/>
+  <circle cx="104" cy="66" r="9" fill="#7b184a"/>
+  <path d="M46 90c10 22 58 22 68 0" fill="none" stroke="#992454" stroke-width="8" stroke-linecap="round"/>
+  <path d="M34 54c10-14 26-22 46-22 20 0 36 8 46 22" fill="none" stroke="#ffc1dd" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="40" cy="118" r="10" fill="#ffe3ef" opacity="0.7"/>
+  <circle cx="122" cy="118" r="8" fill="#ffe3ef" opacity="0.5"/>
+</svg>

--- a/assets/reaction-hopeful.svg
+++ b/assets/reaction-hopeful.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="hope-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f5f1ff"/>
+      <stop offset="55%" stop-color="#d6c9ff"/>
+      <stop offset="100%" stop-color="#b19cff"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="40" fill="url(#hope-bg)"/>
+  <circle cx="56" cy="72" r="9" fill="#45308d"/>
+  <circle cx="104" cy="72" r="9" fill="#45308d"/>
+  <path d="M44 98c12 18 60 18 72 0" fill="none" stroke="#644ac4" stroke-width="8" stroke-linecap="round"/>
+  <path d="M80 40l8 18h-16l8-18z" fill="#fff" opacity="0.7"/>
+  <path d="M36 54c12-12 30-20 44-20s32 8 44 20" fill="none" stroke="#dcd1ff" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="40" cy="120" r="8" fill="#e8e0ff" opacity="0.6"/>
+  <circle cx="120" cy="120" r="10" fill="#e8e0ff" opacity="0.6"/>
+</svg>

--- a/assets/reaction-surprised.svg
+++ b/assets/reaction-surprised.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="surprise-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f2f8ff"/>
+      <stop offset="55%" stop-color="#d7eaff"/>
+      <stop offset="100%" stop-color="#a8ceff"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="40" fill="url(#surprise-bg)"/>
+  <circle cx="56" cy="68" r="9" fill="#1f4073"/>
+  <circle cx="104" cy="68" r="9" fill="#1f4073"/>
+  <ellipse cx="80" cy="104" rx="16" ry="18" fill="#22508d"/>
+  <ellipse cx="80" cy="104" rx="10" ry="12" fill="#fff" opacity="0.65"/>
+  <path d="M38 50l12-8" stroke="#7bb6ff" stroke-width="8" stroke-linecap="round"/>
+  <path d="M122 50l-12-8" stroke="#7bb6ff" stroke-width="8" stroke-linecap="round"/>
+  <path d="M80 34c10 0 18 4 24 10" fill="none" stroke="#c5e0ff" stroke-width="10" stroke-linecap="round"/>
+</svg>

--- a/assets/reaction-waiting.svg
+++ b/assets/reaction-waiting.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="35%" r="75%">
+      <stop offset="0%" stop-color="#fff9d6"/>
+      <stop offset="65%" stop-color="#ffe7a3"/>
+      <stop offset="100%" stop-color="#fcd27d"/>
+    </radialGradient>
+  </defs>
+  <rect width="160" height="160" rx="40" fill="url(#bg)"/>
+  <circle cx="55" cy="70" r="8" fill="#563602"/>
+  <circle cx="105" cy="70" r="8" fill="#563602"/>
+  <path d="M52 110c12 12 44 12 56 0" fill="none" stroke="#6f4100" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="80" cy="32" r="8" fill="#f4b23a"/>
+  <path d="M32 128c14 12 82 12 96 0" fill="none" stroke="#ffe8b7" stroke-width="14" stroke-linecap="round" opacity="0.6"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,43 @@
       align-items: center;
       justify-content: center;
       padding: clamp(24px, 5vw, 48px);
+      position: relative;
+      overflow: hidden;
+    }
+    body::before,
+    body::after {
+      content: "";
+      position: fixed;
+      inset: -30%;
+      z-index: -1;
+      pointer-events: none;
+      background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.8), transparent 55%),
+        radial-gradient(circle at 80% 30%, rgba(255, 184, 255, 0.7), transparent 60%),
+        radial-gradient(circle at 40% 80%, rgba(165, 194, 255, 0.7), transparent 60%);
+      filter: blur(60px);
+      opacity: 0.65;
+      animation: aurora-flow 36s linear infinite;
+      transform-origin: center;
+    }
+    body::after {
+      background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.75), transparent 55%),
+        radial-gradient(circle at 70% 60%, rgba(255, 240, 200, 0.6), transparent 60%),
+        radial-gradient(circle at 60% 20%, rgba(180, 255, 236, 0.5), transparent 65%);
+      filter: blur(80px);
+      opacity: 0.55;
+      animation-duration: 48s;
+      animation-direction: reverse;
+    }
+    @keyframes aurora-flow {
+      0% {
+        transform: translate3d(-4%, -4%, 0) rotate(0deg) scale(1.05);
+      }
+      50% {
+        transform: translate3d(4%, 3%, 0) rotate(180deg) scale(1.1);
+      }
+      100% {
+        transform: translate3d(-4%, -4%, 0) rotate(360deg) scale(1.05);
+      }
     }
     .wrap {
       width: min(960px, 100%);
@@ -120,9 +157,18 @@
       box-shadow: 0 18px 24px rgba(59, 63, 204, 0.18);
     }
     .mascot-face {
-      font-size: clamp(1.4rem, 4.5vw, 1.8rem);
-      color: var(--accent);
+      width: 78%;
+      aspect-ratio: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       transition: transform 0.3s ease;
+    }
+    .mascot-face img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: contain;
     }
     .mascot-hand {
       position: absolute;
@@ -317,11 +363,13 @@
     </header>
 
     <section class="mascot" aria-live="polite">
-      <div class="mascot-figure" aria-hidden="true">
-        <div class="mascot-face" id="mascot-face">(o´∀`o)</div>
+      <div class="mascot-figure">
+        <div class="mascot-face">
+          <img id="mascot-face" src="assets/reaction-waiting.svg" alt="わくわくして入力を待つ表情">
+        </div>
         <div class="mascot-hand"></div>
       </div>
-      <p class="mascot-message" id="mascot-message">こんにちは！今日も楽しくカウントしましょう♪</p>
+      <p class="mascot-message" id="mascot-message">入力を待ってるよ〜！どんな文章が来るかな？</p>
     </section>
 
     <textarea id="t" placeholder="ここに文章を入力／貼り付け"></textarea>
@@ -366,20 +414,51 @@
     const mascot = $('.mascot');
     const mascotFace = $('#mascot-face');
     const mascotMessage = $('#mascot-message');
+    const defaultReaction = {
+      src: 'assets/reaction-waiting.svg',
+      alt: 'わくわくして入力を待つ表情',
+      message: '入力を待ってるよ〜！どんな文章が来るかな？'
+    };
     const reactions = [
-      { face: '(o´∀`o)', message: 'いい感じ！そのペースで続けてね〜。' },
-      { face: '(๑•̀ㅂ•́)و✧', message: '勢いが出てきたよ！たくさん書いちゃおう♪' },
-      { face: '(〃ﾟ3ﾟ〃)', message: 'わぁ、素敵な言葉が並んでる…！' },
-      { face: '( ˘ω˘ )', message: '落ち着いて整えていこっか。' },
-      { face: '(*´꒳`*)', message: 'あとちょっとで完成の予感がするよ〜！' }
+      {
+        src: 'assets/reaction-happy.svg',
+        alt: '嬉しそうに微笑む表情',
+        message: 'いい感じ！そのペースで続けてね〜。'
+      },
+      {
+        src: 'assets/reaction-energetic.svg',
+        alt: '勢いづいてやる気に満ちた表情',
+        message: '勢いが出てきたよ！たくさん書いちゃおう♪'
+      },
+      {
+        src: 'assets/reaction-surprised.svg',
+        alt: '驚いて目を丸くする表情',
+        message: 'わぁ、素敵な言葉が並んでる…！'
+      },
+      {
+        src: 'assets/reaction-calm.svg',
+        alt: '穏やかに見守る表情',
+        message: '落ち着いて整えていこっか。'
+      },
+      {
+        src: 'assets/reaction-hopeful.svg',
+        alt: '希望に満ちた微笑みの表情',
+        message: 'あとちょっとで完成の予感がするよ〜！'
+      }
     ];
     let previousReactionIndex = -1;
+
+    function setReaction(reaction) {
+      if (!mascotFace || !mascotMessage) return;
+      mascotFace.setAttribute('src', reaction.src);
+      mascotFace.setAttribute('alt', reaction.alt);
+      mascotMessage.textContent = reaction.message;
+    }
 
     function playReaction(text){
       if (!mascot || !mascotFace || !mascotMessage) return;
       if (!text.trim()) {
-        mascotFace.textContent = '(・∀・)ﾉ';
-        mascotMessage.textContent = '入力を待ってるよ〜！どんな文章が来るかな？';
+        setReaction(defaultReaction);
       } else {
         let nextIndex = Math.floor(Math.random() * reactions.length);
         if (reactions.length > 1) {
@@ -389,8 +468,7 @@
         }
         previousReactionIndex = nextIndex;
         const reaction = reactions[nextIndex];
-        mascotFace.textContent = reaction.face;
-        mascotMessage.textContent = reaction.message;
+        setReaction(reaction);
       }
       mascot.classList.remove('is-animate');
       void mascot.offsetWidth; // reflow to restart animation
@@ -416,6 +494,8 @@
     update();
     if (t.value) {
       playReaction(t.value);
+    } else {
+      setReaction(defaultReaction);
     }
 
     // サービスワーカー登録（PWAのオフライン化）


### PR DESCRIPTION
## Summary
- add a looping aurora-like ambient background animation behind the layout
- switch the mascot reactions to illustrated SVG images and update the logic to swap them with matching messages

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d5da705950832f9f5648a9e0f16137