### PR TITLE
Improve mobile navigation and add touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,8 @@
       padding: clamp(24px, 5vw, 48px);
       padding-bottom: clamp(120px, 22vh, 160px);
       position: relative;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
     body::before,
     body::after {
@@ -336,18 +337,18 @@
     .global-nav {
       position: fixed;
       left: 50%;
-      bottom: clamp(16px, 5vw, 32px);
+      bottom: clamp(14px, 4vw, 28px);
       transform: translateX(-50%);
       width: min(640px, calc(100% - clamp(24px, 10vw, 80px)));
       z-index: 20;
     }
     .global-nav-inner {
       display: flex;
-      gap: 12px;
-      padding: 14px;
+      gap: 10px;
+      padding: 10px 12px;
       border-radius: 999px;
       background: rgba(15, 14, 43, 0.18);
-      box-shadow: 0 25px 45px rgba(24, 27, 58, 0.16);
+      box-shadow: 0 22px 38px rgba(24, 27, 58, 0.16);
       backdrop-filter: blur(16px);
       -webkit-backdrop-filter: blur(16px);
       border: 1px solid rgba(255, 255, 255, 0.22);
@@ -365,8 +366,8 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      gap: 4px;
-      padding: 12px 16px;
+      gap: 2px;
+      padding: 8px 12px;
       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
       cursor: pointer;
       transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, color 0.18s ease;
@@ -381,16 +382,16 @@
       box-shadow: 0 18px 32px rgba(91, 99, 255, 0.35);
     }
     .nav-button span {
-      font-size: 0.72rem;
-      letter-spacing: 0.18em;
+      font-size: 0.68rem;
+      letter-spacing: 0.16em;
     }
     .nav-button strong {
-      font-size: 0.96rem;
-      letter-spacing: 0.08em;
+      font-size: 0.9rem;
+      letter-spacing: 0.06em;
     }
     .nav-icon {
-      width: 28px;
-      height: 28px;
+      width: 24px;
+      height: 24px;
       display: grid;
       place-items: center;
     }
@@ -442,10 +443,66 @@
       color: var(--text-sub);
       font-size: 0.92rem;
     }
+    .game-touch-controls {
+      display: none;
+      margin-top: 4px;
+    }
+    .game-touch-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-template-areas:
+        "rotate rotate drop"
+        "left down right";
+      gap: 12px;
+    }
+    .game-touch-button {
+      border: none;
+      border-radius: var(--radius-md);
+      background: rgba(255, 255, 255, 0.92);
+      color: var(--text-main);
+      box-shadow: 0 16px 28px rgba(30, 32, 84, 0.18);
+      padding: 10px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      line-height: 1.1;
+      cursor: pointer;
+      touch-action: manipulation;
+      user-select: none;
+      transition: transform 0.16s ease, box-shadow 0.16s ease, background 0.16s ease;
+    }
+    .game-touch-button:active {
+      transform: translateY(1px) scale(0.99);
+      box-shadow: 0 10px 18px rgba(30, 32, 84, 0.24);
+    }
+    .game-touch-button[data-area="rotate"] { grid-area: rotate; }
+    .game-touch-button[data-area="drop"] { grid-area: drop; }
+    .game-touch-button[data-area="left"] { grid-area: left; }
+    .game-touch-button[data-area="down"] { grid-area: down; }
+    .game-touch-button[data-area="right"] { grid-area: right; }
+    .game-touch-icon {
+      font-size: 1.35rem;
+    }
+    .game-touch-text {
+      font-size: 0.76rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+    @media (max-width: 900px) {
+      .game-touch-controls {
+        display: block;
+      }
+    }
     @media (max-width: 640px) {
       body {
         padding: clamp(18px, 8vw, 32px);
         padding-bottom: clamp(120px, 30vw, 220px);
+        align-items: stretch;
+        justify-content: flex-start;
       }
       .wrap {
         padding: clamp(18px, 6vw, 32px);
@@ -459,10 +516,17 @@
       }
       .global-nav-inner {
         gap: 8px;
-        padding: 12px;
+        padding: 9px 10px;
       }
       .nav-button {
-        padding: 10px 12px;
+        padding: 7px 10px;
+        font-size: 0.88rem;
+      }
+      .game-touch-grid {
+        gap: 10px;
+      }
+      .game-touch-button {
+        padding: 10px 8px;
       }
     }
     @media (min-width: 860px) {
@@ -579,6 +643,30 @@
             </div>
           </div>
           <p class="game-instruction">矢印キーで移動＆回転（上キー）。スペースキーで一気にドロップ！音は出ないので静かな場所でも安心です。</p>
+          <div class="game-touch-controls" aria-label="タッチ操作ボタン">
+            <div class="game-touch-grid">
+              <button class="game-touch-button" type="button" data-control="rotate" data-area="rotate" aria-label="回転">
+                <span class="game-touch-icon" aria-hidden="true">↻</span>
+                <span class="game-touch-text">回転</span>
+              </button>
+              <button class="game-touch-button" type="button" data-control="drop" data-area="drop" aria-label="ハードドロップ">
+                <span class="game-touch-icon" aria-hidden="true">⤓</span>
+                <span class="game-touch-text">落下</span>
+              </button>
+              <button class="game-touch-button" type="button" data-control="left" data-area="left" aria-label="左に移動">
+                <span class="game-touch-icon" aria-hidden="true">←</span>
+                <span class="game-touch-text">左</span>
+              </button>
+              <button class="game-touch-button" type="button" data-control="down" data-area="down" aria-label="下に移動">
+                <span class="game-touch-icon" aria-hidden="true">↓</span>
+                <span class="game-touch-text">下</span>
+              </button>
+              <button class="game-touch-button" type="button" data-control="right" data-area="right" aria-label="右に移動">
+                <span class="game-touch-icon" aria-hidden="true">→</span>
+                <span class="game-touch-text">右</span>
+              </button>
+            </div>
+          </div>
           <button id="game-start" type="button">ゲームスタート／リスタート</button>
         </div>
       </div>
@@ -705,6 +793,7 @@
 
     const views = document.querySelectorAll('[data-view]');
     const navButtons = document.querySelectorAll('[data-nav]');
+    const controlButtons = document.querySelectorAll('[data-control]');
     let currentView = 'counter';
     const activeView = document.querySelector('[data-view].is-active');
     if (activeView) {
@@ -1024,6 +1113,64 @@
       restartDropTimer();
     }
 
+    function triggerControl(action) {
+      switch (action) {
+        case 'left':
+          playerMove(-1);
+          break;
+        case 'right':
+          playerMove(1);
+          break;
+        case 'down':
+          playerDrop();
+          break;
+        case 'rotate':
+          playerRotate(1);
+          break;
+        case 'drop':
+          hardDrop();
+          break;
+        default:
+          break;
+      }
+    }
+
+    let controlHoldTimer = null;
+    let controlHoldAction = null;
+    const holdableControls = new Set(['left', 'right', 'down']);
+    const controlIntervals = {
+      left: 140,
+      right: 140,
+      down: 90,
+    };
+
+    function stopControlHold() {
+      if (controlHoldTimer) {
+        clearInterval(controlHoldTimer);
+        controlHoldTimer = null;
+      }
+      controlHoldAction = null;
+    }
+
+    function startControlHold(action) {
+      if (!holdableControls.has(action)) {
+        triggerControl(action);
+        return;
+      }
+      if (controlHoldAction === action) return;
+      stopControlHold();
+      triggerControl(action);
+      if (!isGameRunning || isGameOver || currentView !== 'game') {
+        controlHoldAction = null;
+        return;
+      }
+      const interval = controlIntervals[action] || 140;
+      controlHoldAction = action;
+      controlHoldTimer = setInterval(() => {
+        triggerControl(action);
+      }, interval);
+    }
+
     function handleGameKey(event) {
       if (currentView !== 'game' || !hasGameStarted || isGameOver) return;
       if (!isGameRunning) return;
@@ -1048,6 +1195,7 @@
 
     function switchView(target) {
       if (!target) return;
+      stopControlHold();
       if (target === currentView) {
         if (target === 'game' && hasGameStarted && !isGameOver) {
           resumeGame();
@@ -1081,6 +1229,39 @@
     navButtons.forEach(btn => {
       btn.addEventListener('click', () => switchView(btn.dataset.nav));
     });
+    if (controlButtons.length) {
+      controlButtons.forEach(button => {
+        const action = button.dataset.control;
+        if (!action) return;
+        if (holdableControls.has(action)) {
+          button.addEventListener('pointerdown', event => {
+            event.preventDefault();
+            startControlHold(action);
+          });
+          button.addEventListener('pointerup', event => {
+            event.preventDefault();
+            stopControlHold();
+          });
+          button.addEventListener('pointerleave', stopControlHold);
+          button.addEventListener('pointercancel', stopControlHold);
+          button.addEventListener('click', event => event.preventDefault());
+        } else {
+          button.addEventListener('pointerdown', event => event.preventDefault());
+          button.addEventListener('click', event => {
+            event.preventDefault();
+            triggerControl(action);
+          });
+        }
+        button.addEventListener('keydown', event => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            triggerControl(action);
+          }
+        });
+      });
+      window.addEventListener('pointerup', stopControlHold);
+      window.addEventListener('pointercancel', stopControlHold);
+    }
     if (gameStartButton) {
       gameStartButton.addEventListener('click', () => {
         startGame();


### PR DESCRIPTION
## Summary
- allow mobile pages to scroll naturally by enabling vertical overflow and relaxing small-screen layout constraints
- slim down the floating footer navigation spacing and icon sizing for a more compact footprint
- add on-screen touch controls with repeat handling so the arcade mini game can be played on phones

## Testing
- Manual mobile viewport check

------
https://chatgpt.com/codex/tasks/task_b_68d5e3e93db8832f82c7b0028caec5e5