### PR TITLE
Add landing prediction and clear effects to arcade puzzle

### DIFF
--- a/index.html
+++ b/index.html
@@ -854,6 +854,8 @@
     let isGameRunning = false;
     let isGameOver = false;
     let hasGameStarted = false;
+    const clearEffects = [];
+    const CLEAR_EFFECT_DURATION = 620;
 
     function setBanner(message) {
       if (gameBanner) {
@@ -932,12 +934,171 @@
       });
     }
 
+    function getGhostPosition() {
+      if (!player.matrix) return null;
+      const ghost = {
+        matrix: player.matrix,
+        pos: { x: player.pos.x, y: player.pos.y },
+      };
+      while (!collide(arena, { matrix: ghost.matrix, pos: { x: ghost.pos.x, y: ghost.pos.y + 1 } })) {
+        ghost.pos.y++;
+        if (ghost.pos.y > ROWS) {
+          break;
+        }
+      }
+      return ghost.pos;
+    }
+
+    function drawGhostPiece(matrix, offset) {
+      if (!ctx) return;
+      ctx.save();
+      ctx.globalAlpha = 0.35;
+      matrix.forEach((row, y) => {
+        row.forEach((value, x) => {
+          if (value !== 0) {
+            ctx.fillStyle = COLORS[value] || '#ffffff';
+            ctx.fillRect((x + offset.x) * BLOCK_SIZE, (y + offset.y) * BLOCK_SIZE, BLOCK_SIZE - 1, BLOCK_SIZE - 1);
+          }
+        });
+      });
+      ctx.restore();
+
+      ctx.save();
+      ctx.globalAlpha = 0.4;
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.45)';
+      matrix.forEach((row, y) => {
+        row.forEach((value, x) => {
+          if (value !== 0) {
+            ctx.strokeRect(
+              (x + offset.x) * BLOCK_SIZE + 0.5,
+              (y + offset.y) * BLOCK_SIZE + 0.5,
+              BLOCK_SIZE - 2,
+              BLOCK_SIZE - 2
+            );
+          }
+        });
+      });
+      ctx.restore();
+    }
+
+    function drawPredictionLines(matrix, currentPos, landingPos) {
+      if (!ctx || !canvas) return;
+      const columnInfo = new Map();
+      matrix.forEach((row, y) => {
+        row.forEach((value, x) => {
+          if (!value) return;
+          const column = currentPos.x + x;
+          const startCell = Math.max(0, currentPos.y + y);
+          const endCell = Math.max(startCell + 1, landingPos.y + y + 1);
+          const existing = columnInfo.get(column);
+          if (!existing) {
+            columnInfo.set(column, { startCell, endCell });
+          } else {
+            existing.startCell = Math.min(existing.startCell, startCell);
+            existing.endCell = Math.max(existing.endCell, endCell);
+          }
+        });
+      });
+      columnInfo.forEach((info, column) => {
+        if (column < 0 || column >= COLS) return;
+        const xPos = column * BLOCK_SIZE;
+        const startY = info.startCell * BLOCK_SIZE;
+        const endY = info.endCell * BLOCK_SIZE;
+        const height = Math.max(BLOCK_SIZE * 0.85, endY - startY);
+        ctx.save();
+        const gradient = ctx.createLinearGradient(
+          xPos + BLOCK_SIZE / 2,
+          startY,
+          xPos + BLOCK_SIZE / 2,
+          startY + height
+        );
+        gradient.addColorStop(0, 'rgba(255, 255, 255, 0)');
+        gradient.addColorStop(0.5, 'rgba(91, 99, 255, 0.45)');
+        gradient.addColorStop(1, 'rgba(91, 99, 255, 0)');
+        ctx.fillStyle = gradient;
+        ctx.fillRect(xPos + BLOCK_SIZE * 0.35, startY, BLOCK_SIZE * 0.3, height);
+        ctx.restore();
+
+        ctx.save();
+        ctx.globalAlpha = 0.85;
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.7)';
+        ctx.fillRect(xPos + BLOCK_SIZE / 2 - 1, startY, 2, height);
+        ctx.restore();
+      });
+    }
+
+    function addClearEffect(rowIndex) {
+      if (!canvas) return;
+      clearEffects.push({
+        y: rowIndex * BLOCK_SIZE,
+        start: performance.now(),
+        sparkles: Array.from({ length: 6 }, () => ({
+          x: Math.random() * canvas.width,
+          phase: Math.random() * Math.PI * 2,
+        })),
+      });
+      if (clearEffects.length > 18) {
+        clearEffects.splice(0, clearEffects.length - 18);
+      }
+    }
+
+    function drawClearEffects() {
+      if (!ctx || !canvas || clearEffects.length === 0) return;
+      const now = performance.now();
+      for (let i = clearEffects.length - 1; i >= 0; i--) {
+        const effect = clearEffects[i];
+        const progress = (now - effect.start) / CLEAR_EFFECT_DURATION;
+        if (progress >= 1) {
+          clearEffects.splice(i, 1);
+          continue;
+        }
+        const baseY = effect.y;
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.globalAlpha = 0.45 * (1 - progress);
+        ctx.fillStyle = 'rgba(255, 237, 179, 0.8)';
+        ctx.fillRect(0, baseY, canvas.width, BLOCK_SIZE);
+        ctx.restore();
+
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        const gradient = ctx.createLinearGradient(0, baseY, canvas.width, baseY + BLOCK_SIZE);
+        gradient.addColorStop(0, 'rgba(255, 255, 255, 0)');
+        gradient.addColorStop(0.5, 'rgba(255, 255, 255, 0.9)');
+        gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
+        ctx.globalAlpha = 0.5 * (1 - progress);
+        ctx.fillStyle = gradient;
+        ctx.fillRect(0, baseY, canvas.width, BLOCK_SIZE);
+        ctx.restore();
+
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.globalAlpha = 0.7 * (1 - progress);
+        ctx.fillStyle = '#fffceb';
+        effect.sparkles.forEach((sparkle, index) => {
+          const wave = Math.sin(progress * Math.PI * 1.6 + sparkle.phase);
+          const size = 3 + wave * 3.2;
+          const offsetY = baseY + ((index + 1) / (effect.sparkles.length + 1)) * BLOCK_SIZE;
+          ctx.beginPath();
+          ctx.arc(sparkle.x, offsetY, Math.max(1.5, size), 0, Math.PI * 2);
+          ctx.fill();
+        });
+        ctx.restore();
+      }
+    }
+
     function draw() {
       if (!ctx || !canvas) return;
       ctx.fillStyle = 'rgba(8, 9, 30, 1)';
       ctx.fillRect(0, 0, canvas.width, canvas.height);
       drawMatrix(arena, { x: 0, y: 0 });
+      drawClearEffects();
       if (player.matrix) {
+        const ghostPos = getGhostPosition();
+        if (ghostPos) {
+          drawPredictionLines(player.matrix, player.pos, ghostPos);
+          drawGhostPiece(player.matrix, ghostPos);
+        }
         drawMatrix(player.matrix, player.pos);
       }
     }
@@ -983,6 +1144,7 @@
       let rowCount = 0;
       for (let y = arena.length - 1; y >= 0; y--) {
         if (arena[y].every(value => value !== 0)) {
+          addClearEffect(y);
           arena.splice(y, 1);
           arena.unshift(new Array(COLS).fill(0));
           rowCount++;
@@ -1318,7 +1480,11 @@
     updateScoreboard();
     if (ctx && canvas) {
       ctx.imageSmoothingEnabled = false;
-      draw();
+      const render = () => {
+        draw();
+        requestAnimationFrame(render);
+      };
+      render();
     }
 
     // サービスワーカー登録（PWAのオフライン化）


### PR DESCRIPTION
## Summary
- add a ghost landing preview and column prediction guides for the falling blocks
- introduce animated sparkle effects when cleared lines disappear
- start a continuous render loop to support the new visual feedback

## Testing
- python -m http.server 8000 (manual)


------
https://chatgpt.com/codex/tasks/task_b_68d5f7ae9b20832facd9a26ee02f62c1