### PR TITLE
Add fallback to experimental WebGL context

### DIFF
--- a/index.html
+++ b/index.html
@@ -835,8 +835,21 @@
       btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
     });
 
+    function getWebGLContext(canvasElement) {
+      if (!canvasElement) return null;
+      const contextAttributes = { antialias: true, alpha: true };
+      const contextNames = ['webgl', 'experimental-webgl'];
+      for (const name of contextNames) {
+        const context = canvasElement.getContext(name, contextAttributes);
+        if (context) {
+          return context;
+        }
+      }
+      return null;
+    }
+
     const canvas = document.getElementById('game-board');
-    const gl = canvas ? canvas.getContext('webgl', { antialias: true, alpha: true }) : null;
+    const gl = getWebGLContext(canvas);
     const gameScoreEl = $('#game-score');
     const gameLinesEl = $('#game-lines');
     const gameLevelEl = $('#game-level');


### PR DESCRIPTION
## Summary
- add a helper to request a WebGL context with a fallback to the experimental name
- ensure the puzzle view initializes WebGL on browsers that only expose the legacy context

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_b_68d60bc03780832fbe8c4d571b0519d1