### PR TITLE
Fix WebGL canvas resize fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -1136,8 +1136,16 @@
     function resizeWebGLCanvas(glContext, canvasElement) {
       if (!canvasElement) return false;
       const dpr = window.devicePixelRatio || 1;
-      const displayWidth = Math.floor(canvasElement.clientWidth * dpr);
-      const displayHeight = Math.floor(canvasElement.clientHeight * dpr);
+      const clientWidth = canvasElement.clientWidth || canvasElement.width;
+      let clientHeight = canvasElement.clientHeight;
+      if (!clientHeight) {
+        const aspectRatio = canvasElement.height && canvasElement.width
+          ? canvasElement.height / canvasElement.width
+          : ROWS / COLS;
+        clientHeight = clientWidth * aspectRatio;
+      }
+      const displayWidth = Math.floor(clientWidth * dpr);
+      const displayHeight = Math.floor(clientHeight * dpr);
       if (canvasElement.width !== displayWidth || canvasElement.height !== displayHeight) {
         canvasElement.width = displayWidth;
         canvasElement.height = displayHeight;


### PR DESCRIPTION
## Summary
- ensure the WebGL canvas keeps a sensible size even when the game view is hidden
- derive the fallback height from the canvas aspect ratio so the board renders once it becomes visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d61a663ee8832f8028d7b0d3ec6a21