### PR TITLE
Fix merge bounds handling to restore line clears

### DIFF
--- a/index.html
+++ b/index.html
@@ -1677,10 +1677,21 @@
 
     function merge(arena, player) {
       player.matrix.forEach((row, y) => {
+        const targetY = y + player.pos.y;
+        if (targetY < 0 || targetY >= arena.length) {
+          return;
+        }
+        const arenaRow = arena[targetY];
+        if (!Array.isArray(arenaRow)) {
+          return;
+        }
         row.forEach((value, x) => {
-          if (value !== 0) {
-            arena[y + player.pos.y][x + player.pos.x] = value;
+          if (value === 0) return;
+          const targetX = x + player.pos.x;
+          if (targetX < 0 || targetX >= arenaRow.length) {
+            return;
           }
+          arenaRow[targetX] = value;
         });
       });
     }


### PR DESCRIPTION
## Summary
- guard arena merge logic so out-of-bounds cells are ignored instead of throwing
- ensure line-clearing proceeds even when pieces overlap the top or sides of the board

## Testing
- manual: started the game, dropped pieces, and confirmed lines clear properly

------
https://chatgpt.com/codex/tasks/task_b_68d63b160950832f93f5e29e05afada7