### PR TITLE
Add sticky header navigation with collapsible menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,11 +50,22 @@
       align-items: center;
       justify-content: flex-start;
       padding: clamp(28px, 5vw, 52px);
-      padding-top: clamp(48px, 8vh, 80px);
-      padding-bottom: clamp(136px, 22vh, 180px);
+      padding-top: clamp(32px, 7vh, 72px);
+      padding-bottom: clamp(48px, 14vh, 96px);
       position: relative;
       overflow-x: hidden;
       overflow-y: auto;
+    }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
     }
     body::before,
     body::after {
@@ -110,6 +121,284 @@
       position: relative;
       overflow: hidden;
       isolation: isolate;
+    }
+    .site-header {
+      width: min(1024px, 100%);
+      position: sticky;
+      top: clamp(12px, 4vw, 24px);
+      z-index: 30;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: clamp(16px, 3vw, 28px);
+      margin-bottom: clamp(28px, 5vw, 44px);
+      padding: clamp(16px, 2.6vw, 24px) clamp(20px, 4vw, 32px);
+      border-radius: var(--radius-md);
+      background: linear-gradient(140deg, rgba(15, 26, 56, 0.92), rgba(20, 42, 90, 0.88));
+      border: 1px solid rgba(64, 122, 255, 0.38);
+      box-shadow: var(--shadow-soft);
+      backdrop-filter: blur(24px);
+      -webkit-backdrop-filter: blur(24px);
+      overflow: hidden;
+    }
+    .site-header::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 20% 20%, rgba(48, 214, 255, 0.25), transparent 52%),
+        radial-gradient(circle at 80% 15%, rgba(129, 87, 255, 0.18), transparent 60%),
+        linear-gradient(135deg, rgba(16, 36, 80, 0.65), rgba(10, 20, 52, 0.3));
+      opacity: 0.8;
+      pointer-events: none;
+      z-index: -1;
+    }
+    .site-brand {
+      display: flex;
+      align-items: center;
+      gap: clamp(12px, 2.6vw, 18px);
+    }
+    .brand-emblem {
+      width: clamp(42px, 6vw, 54px);
+      height: clamp(42px, 6vw, 54px);
+      border-radius: 14px;
+      display: grid;
+      place-items: center;
+      background: linear-gradient(135deg, rgba(48, 214, 255, 0.35), rgba(129, 87, 255, 0.32));
+      box-shadow: inset 0 0 0 1px rgba(63, 130, 255, 0.4);
+      color: var(--accent);
+      font-family: "Chakra Petch", "Noto Sans JP", "Hiragino Sans", "ヒラギノ角ゴ ProN", "Yu Gothic", YuGothic, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      font-size: clamp(0.92rem, 2.6vw, 1.1rem);
+      letter-spacing: 0.28em;
+      text-transform: uppercase;
+    }
+    .brand-text {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+    .brand-text strong {
+      font-size: clamp(1.1rem, 3.2vw, 1.38rem);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-family: "Chakra Petch", "Noto Sans JP", "Hiragino Sans", "ヒラギノ角ゴ ProN", "Yu Gothic", YuGothic, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    }
+    .brand-text span {
+      font-size: 0.82rem;
+      color: var(--text-muted);
+      letter-spacing: 0.24em;
+      text-transform: uppercase;
+    }
+    .menu-toggle {
+      margin-left: auto;
+      border: 1px solid rgba(63, 130, 255, 0.45);
+      background: rgba(16, 30, 60, 0.82);
+      color: var(--text-sub);
+      border-radius: 999px;
+      width: 46px;
+      height: 46px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      box-shadow: inset 0 0 0 1px rgba(48, 214, 255, 0.16);
+      transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+    }
+    .menu-toggle span {
+      display: block;
+      width: 18px;
+      height: 2px;
+      background: currentColor;
+      position: relative;
+    }
+    .menu-toggle span::before,
+    .menu-toggle span::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      width: 18px;
+      height: 2px;
+      background: currentColor;
+      transition: transform var(--transition), opacity var(--transition);
+    }
+    .menu-toggle span::before {
+      transform: translateY(-6px);
+    }
+    .menu-toggle span::after {
+      transform: translateY(6px);
+    }
+    .site-header.is-menu-open .menu-toggle span {
+      background: transparent;
+    }
+    .site-header.is-menu-open .menu-toggle span::before {
+      transform: translateY(0) rotate(45deg);
+    }
+    .site-header.is-menu-open .menu-toggle span::after {
+      transform: translateY(0) rotate(-45deg);
+    }
+    .menu-toggle:hover {
+      transform: translateY(-1px);
+      box-shadow: inset 0 0 0 1px rgba(48, 214, 255, 0.24), 0 12px 28px rgba(4, 12, 32, 0.55);
+      background: rgba(22, 44, 88, 0.9);
+    }
+    .site-menu {
+      flex-basis: 100%;
+      display: none;
+      flex-direction: column;
+      gap: clamp(16px, 3vw, 26px);
+    }
+    .site-header.is-menu-open .site-menu {
+      display: flex;
+    }
+    .site-nav {
+      display: grid;
+      gap: 12px;
+    }
+    .nav-button {
+      width: 100%;
+      border: 1px solid rgba(63, 130, 255, 0.32);
+      border-radius: calc(var(--radius-md) - 6px);
+      background: linear-gradient(130deg, rgba(14, 30, 68, 0.92), rgba(20, 44, 96, 0.86));
+      color: var(--text-sub);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 12px 16px;
+      cursor: pointer;
+      text-align: left;
+      transition: transform var(--transition), box-shadow var(--transition), background var(--transition), color var(--transition);
+      box-shadow: 0 12px 28px rgba(4, 12, 32, 0.45);
+      font-family: "Chakra Petch", "Noto Sans JP", "Hiragino Sans", "ヒラギノ角ゴ ProN", "Yu Gothic", YuGothic, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      letter-spacing: 0.06em;
+    }
+    .nav-button .nav-text {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+    .nav-button strong {
+      font-size: 0.98rem;
+      letter-spacing: 0.08em;
+    }
+    .nav-button span {
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      color: var(--text-muted);
+    }
+    .nav-icon {
+      width: 26px;
+      height: 26px;
+      display: grid;
+      place-items: center;
+      color: var(--accent);
+    }
+    .nav-button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 22px 42px rgba(4, 12, 32, 0.6);
+      background: linear-gradient(130deg, rgba(20, 46, 96, 0.96), rgba(34, 78, 150, 0.88));
+      color: #fff;
+    }
+    .nav-button.is-active {
+      background: linear-gradient(130deg, var(--accent) 0%, var(--accent-secondary) 100%);
+      color: #fff;
+      box-shadow: 0 26px 48px rgba(4, 12, 32, 0.68);
+      border-color: rgba(129, 87, 255, 0.5);
+    }
+    .header-quick-stats {
+      border-radius: calc(var(--radius-md) - 6px);
+      border: 1px solid rgba(63, 130, 255, 0.32);
+      background: linear-gradient(135deg, rgba(16, 34, 72, 0.88), rgba(24, 52, 110, 0.82));
+      box-shadow: 0 18px 36px rgba(4, 12, 32, 0.45);
+      padding: 10px 14px;
+      color: var(--text-sub);
+    }
+    .header-quick-stats summary {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      cursor: pointer;
+      list-style: none;
+    }
+    .header-quick-stats summary::-webkit-details-marker {
+      display: none;
+    }
+    .summary-title {
+      font-size: 0.8rem;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+    }
+    .summary-count {
+      display: inline-flex;
+      align-items: baseline;
+      gap: 6px;
+      font-family: "Chakra Petch", "Noto Sans JP", "Hiragino Sans", "ヒラギノ角ゴ ProN", "Yu Gothic", YuGothic, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      color: var(--accent);
+    }
+    .summary-count strong {
+      font-size: 1.12rem;
+      letter-spacing: 0.06em;
+    }
+    .quick-stats-grid {
+      margin-top: 12px;
+      display: grid;
+      gap: 10px;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    }
+    .quick-stat {
+      padding: 12px 14px;
+      border-radius: calc(var(--radius-md) - 8px);
+      background: linear-gradient(135deg, rgba(18, 36, 80, 0.88), rgba(16, 40, 92, 0.82));
+      border: 1px solid rgba(63, 130, 255, 0.28);
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      box-shadow: inset 0 1px 0 rgba(48, 214, 255, 0.12);
+    }
+    .quick-stat span {
+      font-size: 0.68rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      color: var(--text-muted);
+    }
+    .quick-stat strong {
+      font-size: 1.1rem;
+      letter-spacing: 0.08em;
+      font-variant-numeric: tabular-nums;
+    }
+    @media (min-width: 840px) {
+      .site-header {
+        flex-wrap: nowrap;
+        align-items: center;
+      }
+      .menu-toggle {
+        display: none;
+      }
+      .site-menu {
+        display: flex !important;
+        flex-direction: row;
+        align-items: center;
+        justify-content: flex-end;
+        gap: clamp(20px, 4vw, 36px);
+        flex: 1;
+      }
+      .site-nav {
+        display: flex;
+        gap: clamp(12px, 2vw, 20px);
+      }
+      .nav-button {
+        padding: 12px clamp(18px, 2.4vw, 24px);
+        width: auto;
+        min-width: 200px;
+      }
+      .header-quick-stats {
+        max-width: 340px;
+      }
+      .quick-stats-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
     }
     .wrap::before {
       content: "";
@@ -488,68 +777,6 @@
       text-transform: uppercase;
       font-family: "Chakra Petch", "Noto Sans JP", "Hiragino Sans", "ヒラギノ角ゴ ProN", "Yu Gothic", YuGothic, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     }
-    .global-nav {
-      position: fixed;
-      left: 50%;
-      bottom: clamp(14px, 4vw, 28px);
-      transform: translateX(-50%);
-      width: min(640px, calc(100% - clamp(24px, 10vw, 80px)));
-      z-index: 20;
-    }
-    .global-nav-inner {
-      display: flex;
-      gap: 10px;
-      padding: 10px 12px;
-      border-radius: 999px;
-      background: linear-gradient(135deg, rgba(12, 26, 60, 0.86), rgba(16, 36, 78, 0.86));
-      box-shadow: 0 26px 52px rgba(4, 10, 28, 0.78);
-      backdrop-filter: blur(22px);
-      -webkit-backdrop-filter: blur(22px);
-      border: 1px solid rgba(63, 130, 255, 0.32);
-    }
-    .nav-button {
-      flex: 1;
-      border: none;
-      border-radius: 999px;
-      background: rgba(12, 22, 46, 0.9);
-      color: var(--text-sub);
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      gap: 2px;
-      padding: 8px 12px;
-      box-shadow: inset 0 1px 0 rgba(48, 214, 255, 0.18);
-      cursor: pointer;
-      transition: transform var(--transition), box-shadow var(--transition), background var(--transition), color var(--transition);
-      font-family: "Chakra Petch", "Noto Sans JP", "Hiragino Sans", "ヒラギノ角ゴ ProN", "Yu Gothic", YuGothic, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    }
-    .nav-button:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 20px 36px rgba(6, 18, 42, 0.68);
-    }
-    .nav-button.is-active {
-      background: linear-gradient(130deg, var(--accent) 0%, var(--accent-secondary) 100%);
-      color: #fff;
-      box-shadow: 0 24px 52px rgba(6, 18, 42, 0.8);
-    }
-    .nav-button span {
-      font-size: 0.68rem;
-      letter-spacing: 0.16em;
-    }
-    .nav-button strong {
-      font-size: 0.9rem;
-      letter-spacing: 0.06em;
-    }
-    .nav-icon {
-      width: 24px;
-      height: 24px;
-      display: grid;
-      place-items: center;
-    }
     .game-layout {
       display: grid;
       gap: clamp(20px, 3.6vw, 32px);
@@ -684,12 +911,32 @@
         display: block;
       }
     }
+    @media (max-width: 900px) {
+      .site-header {
+        top: clamp(10px, 6vw, 18px);
+      }
+    }
+    @media (max-width: 720px) {
+      .site-menu {
+        border-radius: calc(var(--radius-md) - 6px);
+        border: 1px solid rgba(63, 130, 255, 0.28);
+        background: linear-gradient(140deg, rgba(12, 28, 64, 0.9), rgba(16, 38, 82, 0.86));
+        padding: 18px;
+      }
+      .header-quick-stats {
+        background: linear-gradient(135deg, rgba(16, 32, 72, 0.92), rgba(20, 46, 102, 0.86));
+      }
+    }
     @media (max-width: 640px) {
       body {
         padding: clamp(18px, 8vw, 32px);
-        padding-bottom: clamp(120px, 30vw, 220px);
+        padding-bottom: clamp(64px, 24vw, 120px);
         align-items: stretch;
         justify-content: flex-start;
+      }
+      .site-header {
+        margin-bottom: clamp(22px, 6vw, 32px);
+        padding: clamp(14px, 5vw, 20px) clamp(16px, 5vw, 22px);
       }
       .wrap {
         padding: clamp(18px, 6vw, 32px);
@@ -697,20 +944,15 @@
       .hero-characters {
         display: none;
       }
+      .nav-button {
+        padding: 12px 14px;
+      }
       .actions {
         justify-content: stretch;
       }
       button {
         width: 100%;
         justify-content: center;
-      }
-      .global-nav-inner {
-        gap: 8px;
-        padding: 9px 10px;
-      }
-      .nav-button {
-        padding: 7px 10px;
-        font-size: 0.88rem;
       }
       .info-badges {
         grid-template-columns: minmax(0, 1fr);
@@ -753,6 +995,73 @@
   </style>
 </head>
 <body>
+  <header class="site-header" aria-label="アプリケーションヘッダー">
+    <div class="site-brand">
+      <span class="brand-emblem">NCA</span>
+      <div class="brand-text">
+        <strong>Neon Count Arena</strong>
+        <span>Focus Suite</span>
+      </div>
+    </div>
+    <button class="menu-toggle" type="button" aria-controls="site-menu" aria-expanded="false">
+      <span class="sr-only">メニューを開閉</span>
+      <span aria-hidden="true"></span>
+    </button>
+    <div class="site-menu" id="site-menu" aria-hidden="true">
+      <nav class="site-nav" aria-label="メインメニュー">
+        <button class="nav-button is-active" type="button" data-nav="counter" aria-pressed="true">
+          <div class="nav-icon" aria-hidden="true">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M4 7H20" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+              <path d="M6 12H18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+              <path d="M9 17H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </div>
+          <div class="nav-text">
+            <strong>文字カウンター</strong>
+            <span>Count</span>
+          </div>
+        </button>
+        <button class="nav-button" type="button" data-nav="game" aria-pressed="false">
+          <div class="nav-icon" aria-hidden="true">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <rect x="4" y="4" width="7" height="7" rx="1.2" fill="currentColor"/>
+              <rect x="13" y="4" width="7" height="9" rx="1.2" stroke="currentColor" stroke-width="1.5"/>
+              <rect x="4" y="13" width="7" height="7" rx="1.2" stroke="currentColor" stroke-width="1.5"/>
+              <rect x="13" y="15" width="7" height="5" rx="1.2" fill="currentColor"/>
+            </svg>
+          </div>
+          <div class="nav-text">
+            <strong>ゲーム</strong>
+            <span>Arcade</span>
+          </div>
+        </button>
+      </nav>
+      <details class="header-quick-stats" open>
+        <summary>
+          <span class="summary-title">ライブメーター</span>
+          <span class="summary-count" aria-live="polite">
+            <strong id="chars-compact">0</strong>
+            <span>文字</span>
+          </span>
+        </summary>
+        <div class="quick-stats-grid" aria-live="polite">
+          <div class="quick-stat">
+            <span>Characters</span>
+            <strong id="chars-quick">0</strong>
+          </div>
+          <div class="quick-stat">
+            <span>Lines</span>
+            <strong id="lines-quick">0</strong>
+          </div>
+          <div class="quick-stat">
+            <span>Words</span>
+            <strong id="words-quick">0</strong>
+          </div>
+        </div>
+      </details>
+    </div>
+  </header>
   <main class="wrap">
     <div class="hero-characters" aria-hidden="true">
       <figure class="hero-character hero-character--dog">
@@ -925,40 +1234,21 @@
     </section>
   </main>
 
-  <nav class="global-nav" aria-label="メインメニュー">
-    <div class="global-nav-inner">
-      <button class="nav-button is-active" type="button" data-nav="counter" aria-pressed="true">
-        <div class="nav-icon" aria-hidden="true">
-          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M4 7H20" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-            <path d="M6 12H18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-            <path d="M9 17H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-          </svg>
-        </div>
-        <strong>文字カウンター</strong>
-        <span>Count</span>
-      </button>
-      <button class="nav-button" type="button" data-nav="game" aria-pressed="false">
-        <div class="nav-icon" aria-hidden="true">
-          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect x="4" y="4" width="7" height="7" rx="1.2" fill="currentColor"/>
-            <rect x="13" y="4" width="7" height="9" rx="1.2" stroke="currentColor" stroke-width="1.5"/>
-            <rect x="4" y="13" width="7" height="7" rx="1.2" stroke="currentColor" stroke-width="1.5"/>
-            <rect x="13" y="15" width="7" height="5" rx="1.2" fill="currentColor"/>
-          </svg>
-        </div>
-        <strong>ゲーム</strong>
-        <span>Arcade</span>
-      </button>
-    </div>
-  </nav>
-
   <script>
     const $ = s => document.querySelector(s);
     const t = $('#t'), chars = $('#chars'), lines = $('#lines'), words = $('#words');
+    const charsCompact = $('#chars-compact');
+    const charsQuick = $('#chars-quick');
+    const linesQuick = $('#lines-quick');
+    const wordsQuick = $('#words-quick');
     const mascot = $('.mascot');
     const mascotFace = $('#mascot-face');
     const mascotMessage = $('#mascot-message');
+    const menuToggle = document.querySelector('.menu-toggle');
+    const siteHeader = document.querySelector('.site-header');
+    const siteMenu = document.getElementById('site-menu');
+    const desktopMedia = window.matchMedia('(min-width: 840px)');
+    let isMenuOpen = false;
     const defaultReaction = {
       src: 'assets/reaction-waiting.svg',
       alt: 'わくわくして入力を待つ表情',
@@ -1022,10 +1312,25 @@
 
     function update(triggerAnimation = false){
       const v = t.value;
-      chars.textContent = [...v].length; // サロゲート対策
-      lines.textContent = v === '' ? 0 : v.split(/\r\n|\r|\n/).length;
+      const charCount = [...v].length; // サロゲート対策
+      const lineCount = v === '' ? 0 : v.split(/\r\n|\r|\n/).length;
       const w = v.trim().split(/\s+/).filter(Boolean);
-      words.textContent = v.trim() ? w.length : 0;
+      const wordCount = v.trim() ? w.length : 0;
+      chars.textContent = charCount;
+      lines.textContent = lineCount;
+      words.textContent = wordCount;
+      if (charsCompact) {
+        charsCompact.textContent = charCount;
+      }
+      if (charsQuick) {
+        charsQuick.textContent = charCount;
+      }
+      if (linesQuick) {
+        linesQuick.textContent = lineCount;
+      }
+      if (wordsQuick) {
+        wordsQuick.textContent = wordCount;
+      }
       localStorage.setItem('text', v); // 直近内容を保持
       if (triggerAnimation) {
         playReaction(v);
@@ -2235,8 +2540,65 @@
       }
     }
 
+    function applyMenuState(open) {
+      if (siteHeader) {
+        siteHeader.classList.toggle('is-menu-open', open);
+      }
+      if (menuToggle) {
+        menuToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      }
+      if (siteMenu) {
+        siteMenu.setAttribute('aria-hidden', open ? 'false' : 'true');
+      }
+    }
+
+    function initializeMenu() {
+      if (desktopMedia.matches) {
+        applyMenuState(true);
+      } else {
+        applyMenuState(isMenuOpen);
+      }
+    }
+
+    initializeMenu();
+    desktopMedia.addEventListener('change', event => {
+      if (event.matches) {
+        applyMenuState(true);
+      } else {
+        isMenuOpen = false;
+        applyMenuState(false);
+      }
+    });
+
+    if (menuToggle) {
+      menuToggle.addEventListener('click', () => {
+        if (desktopMedia.matches) return;
+        isMenuOpen = !isMenuOpen;
+        applyMenuState(isMenuOpen);
+      });
+    }
+
+    function collapseMenuOnMobile() {
+      if (desktopMedia.matches || !isMenuOpen) return;
+      isMenuOpen = false;
+      applyMenuState(false);
+    }
+
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape' && !desktopMedia.matches && isMenuOpen) {
+        isMenuOpen = false;
+        applyMenuState(false);
+        if (menuToggle) {
+          menuToggle.focus();
+        }
+      }
+    });
+
     navButtons.forEach(btn => {
-      btn.addEventListener('click', () => switchView(btn.dataset.nav));
+      btn.addEventListener('click', () => {
+        switchView(btn.dataset.nav);
+        collapseMenuOnMobile();
+      });
     });
     const shouldPreventPointerDefault = event => {
       return event.pointerType !== 'touch';


### PR DESCRIPTION
## Summary
- replace the footer navigation with a sticky header that includes responsive view toggles and a hamburger control
- introduce a collapsible quick stats drawer in the header that mirrors character, line, and word counts
- update client-side logic to synchronize compact stats and manage the mobile menu state for accessibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7b70e8a20832f991fac318216825c